### PR TITLE
Fix Qt5 build on clean Windows

### DIFF
--- a/Telegram/build/prepare/prepare.py
+++ b/Telegram/build/prepare/prepare.py
@@ -1302,7 +1302,14 @@ if buildQt5:
     stage('qt_5_15_12', """
     git clone https://github.com/qt/qt5.git qt_5_15_12
     cd qt_5_15_12
+win:
+    SET PATH_BACKUP_=%PATH%
+    SET PATH=%ROOT_DIR%\\ThirdParty\\msys64\\usr\\bin;%PATH%
+common:
     perl init-repository --module-subset=qtbase,qtimageformats,qtsvg
+win:
+    SET PATH=%PATH_BACKUP_%
+common:
     git checkout v5.15.12-lts-lgpl
     git submodule update qtbase qtimageformats qtsvg
 depends:patches/qtbase_5.15.12/*.patch


### PR DESCRIPTION
This PR fixes building of Windows version on clean system.

## The problem

Perl is now used from MSYS instead of Strawberry, which leads to Qt 5 build failure, because it wasn't found in `PATH` environment variable:

![](https://github.com/EricKotato/tdesktop/assets/2903496/63b22112-5790-4e55-969a-0ae352195033)

Those who built TDesktop prior this change (including me) haven't spotted the difference, since Strawberry Perl is probably in their `PATH`.

## The solution

This can be solved by temporarily adding MSYS's `/usr/bin/` folder to system `PATH`, like in FFmpeg or libvpx build. `SET CHERE_INVOKING=enabled_from_arguments` and `SET MSYS2_PATH_TYPE=inherit` are not needed, since Perl script only initializes Qt repo, and is not used in building.

I've also tried to replace `perl` with `%THIRDPARTY_DIR%\\msys64\\usr\\bin\\perl.exe`, but this won't work since `dirname` at minimum is used inside the Perl script. Restoring PATH is also important because otherwise `link.exe` will be used from MSYS, not from Visual Studio, which will lead to Qt build failure.

## Attribution

@phagleb for screenshot and testing.